### PR TITLE
aiorwlock 1.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,30 +10,47 @@ source:
   sha256: 83f12d87df4b9728a0b8fda1756585ab0d652b107bab59c6084e1b1ad692ab45
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
   number: 0
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.7
+    - python
 
 test:
   imports:
     - aiorwlock
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/aio-libs/aiorwlock
   summary: Read write lock for asyncio.
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
+  description: |
+    Read write lock for asyncio. A RWLock maintains a pair of associated locks, 
+    one for read-only operations and one for writing. 
+    The read lock may be held simultaneously by multiple reader tasks, 
+    so long as there are no writers. The write lock is exclusive.
+    Whether or not a read-write lock will improve performance 
+    over the use of a mutual exclusion lock depends on the frequency 
+    that the data is read compared to being modified. For example, 
+    a collection that is initially populated with data and thereafter infrequently modified, 
+    while being frequently searched is an ideal candidate for the use of a read-write lock. 
+    However, if updates become frequent then the data spends most of its time being exclusively locked 
+    and there is little, if any increase in concurrency.
+  doc_url: https://github.com/aio-libs/aiorwlock
+  dev_url: https://github.com/aio-libs/aiorwlock
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: https://github.com/aio-libs/aiorwlock/blob/v1.3.0/CHANGES.rst
License: https://github.com/aio-libs/aiorwlock/blob/v1.3.0/LICENSE
Requirements: https://github.com/aio-libs/aiorwlock/blob/v1.3.0/setup.py

Actions:

1. Remove noarch
2. Skip py<37
3. Add --no-deps
4. Remove python pinnings in host and run
5. Add missing setuptools and wheel to host
8. Add license_family
9. Add description
10. Add doc & dev urls

Notes:
- `ray_packages` requires it